### PR TITLE
feat: Enhance form component and dropdown component, add local caching

### DIFF
--- a/src/scripts/components/k-suburl-generator.ts
+++ b/src/scripts/components/k-suburl-generator.ts
@@ -1,21 +1,24 @@
 import type { Form } from "@scripts/components/k-form";
 import type { EndpointExtendConfigPrototype, EndpointPrototype } from "@config/AvalibleOptoutFormat";
 import { getDefaultBackend } from "@scripts/utils/getDefaultBackend";
+
 class SubURLGenerator extends HTMLElement {
     TargetExtendConfig: ( "RemoteConfig" | "isUDP" )[];
     Endpoints: EndpointPrototype[] = JSON.parse(this.dataset.endpoints);
     defaultBackend = getDefaultBackend();
+
     constructor () {
         super()
         this.GenerateButton.addEventListener("click", () => {this.CheckAndGenerate()});
         this.CopyButton.addEventListener("click", () => {this.CopyURL()});
-        this.BasicConfigElement.Endpoint.querySelector("k-dropdown").addEventListener("DropdownSelect", (event: CustomEvent) => {this.ChangeEndpoint(event)});
+        this.BasicConfigElement.Endpoint.addEventListener("change", (event: CustomEvent) => {this.ChangeEndpoint(event)});
         document.body.dataset.defaultBackend = this.defaultBackend;
         customElements.whenDefined("k-form").then(() => {
             this.BasicConfigElement.Backend.setDetail(`${this.BasicConfigElement.Backend.getDetail()} (${this.defaultBackend})`);
             console.info("[k-sub-url-generator] k-form registration detected, default backend modified")
         })
     }
+
     GenerateButton = this.querySelector("button#generate") as HTMLButtonElement;
     CopyButton = this.querySelector("button#copy") as HTMLButtonElement;
     MsgBlock = this.querySelector("code") as HTMLElement;
@@ -33,6 +36,7 @@ class SubURLGenerator extends HTMLElement {
         isSSUoT: this.querySelector("k-form#isSSUoT") as Form,
         ForcedWS0RTT: this.querySelector("k-form#ForcedWS0RTT") as Form,
     }
+
     GetEndpoint (EndpointPath: string = this.BasicConfigElement.Endpoint.get()) {
         for (let i of this.Endpoints) {
             if (i.value === EndpointPath) {
@@ -41,6 +45,7 @@ class SubURLGenerator extends HTMLElement {
         }
         throw `no targeted endpoint found, expected value ${EndpointPath}`
     }
+
     ChangeEndpoint (event: CustomEvent) {
         const SelectedEndpointPath: string = event.detail.selectedValue;
         let Endpoint: EndpointPrototype = this.GetEndpoint(SelectedEndpointPath);
@@ -54,6 +59,7 @@ class SubURLGenerator extends HTMLElement {
             }
         }
     }
+
     CheckAndGenerate () {
         const BasicConfig = {
             SubURL: this.BasicConfigElement.SubURL.get(),
@@ -112,6 +118,7 @@ class SubURLGenerator extends HTMLElement {
         Config.HTTPHeaders !== "{}" && URLObj.searchParams.append("http_headers", Config.HTTPHeaders)
         return URLObj.toString();
     }
+
     CopyURL () {
         if (!navigator.clipboard) {
             alert("navigator.clipboard API not found on your drowser")

--- a/src/scripts/components/k-switch.ts
+++ b/src/scripts/components/k-switch.ts
@@ -1,19 +1,48 @@
 export class Switch extends HTMLElement {
-    checked: boolean = this.dataset.checked === "true"
+    private _checked: boolean = this.dataset.checked === "true"
+
     constructor () {
         super ();
-
+        
         this.addEventListener("click", () => {
-            this.setChecked(!this.getChecked())
+            this.updateCheckedState(!this.getChecked(), true);
+        });
+
+        // Listen for external switch events
+        this.addEventListener("SwitchChange", (event: CustomEvent) => {
+            this.updateCheckedState(event.detail.checked, false);
         });
     }
-    setChecked (TargetStatus: boolean) {
-        this.checked = TargetStatus;
-        this.dataset.checked = this.checked.toString();
+
+    get checked(): boolean {
+        return this._checked;
     }
-    getChecked () {
+
+    set checked(value: boolean) {
+        this.updateCheckedState(value, false);
+    }
+
+    private updateCheckedState(value: boolean, dispatchEvent: boolean = true) {
+        this._checked = value;
+        this.dataset.checked = value.toString();
+
+        if (dispatchEvent) {
+            this.dispatchEvent(new CustomEvent("SwitchChange", {
+                detail: { checked: value },
+                bubbles: true
+            }));
+            this.dispatchEvent(new Event("change"));
+        }
+    }
+
+    setChecked(TargetStatus: boolean) {
+        this.updateCheckedState(TargetStatus, true);
+    }
+
+    getChecked() {
         return this.checked;
     }
 }
+
 customElements.define("k-switch", Switch);
 console.info("[k-switch] registered")


### PR DESCRIPTION
- Added local caching functionality to the `k-form` component, supporting `textarea`, `input`, `k-switch`, and `k-dropdown` types.
- The `k-form` component will attempt to load cached values during initialization.
- The `k-form` component will automatically cache when the value changes.
- Fixed the issue where the `DropdownSelect` event was not correctly triggered after the selected value of the `k-dropdown` component was updated.
- Optimized the initialization logic of the `k-dropdown` component, adding delayed initialization to ensure that child components have been properly initialized.
- Modified the `k-switch` component, now allowing it to listen to external `SwitchChange` events to update its state.
- Adjusted the internal implementation of the `k-switch` component, using a private variable `_checked` to store the selected state and accessing it via the `checked` property.
- Fixed the issue where the `change` event could not be correctly triggered when clicking the `k-switch` component.
- Added some logs for easier debugging.