### PR TITLE
feat: Add upstream response header passthrough

### DIFF
--- a/functions/sub/clash-meta.js
+++ b/functions/sub/clash-meta.js
@@ -6,7 +6,7 @@ import Yaml from "js-yaml";
 export async function onRequest (context, isClashOriginal = false) {
     const { request } = context;
     const URLObject = new URL(request.url);
-    let Proxies = await getParsedSubData(
+    let { data: Proxies, headers: UpstreamHeaders } = await getParsedSubData(
         URLObject.searchParams.get("url"), 
         context.env.EdgeSubDB, 
         URLObject.searchParams.get("show_host") === "true",
@@ -48,13 +48,15 @@ export async function onRequest (context, isClashOriginal = false) {
         }
     }
 
-    const ResponseBody = Yaml.dump(ClashMetaConfigObject)
+    let YAMLString = Yaml.dump(ClashMetaConfigObject);
 
-    return new Response(ResponseBody, {
-        status: 200,
-        headers: {
-            "Content-Type": "text/plain; charset=utf-8",
-            "Content-Length": ResponseBody.length
-        }
+    // 构建响应头
+    const responseHeaders = {
+        'Content-Type': 'text/yaml; charset=utf-8',
+        ...UpstreamHeaders
+    };
+
+    return new Response(YAMLString, {
+        headers: responseHeaders
     })
 }

--- a/functions/sub/debug.js
+++ b/functions/sub/debug.js
@@ -3,19 +3,22 @@ import getParsedSubData from "../internal/getParsedSubData.ts";
 export async function onRequest (context) {
     const { request } = context;
     const URLObject = new URL(request.url);
-    const ParsedSubData = await getParsedSubData(
+    let { data: ParsedSubData, headers: UpstreamHeaders } = await getParsedSubData(
         URLObject.searchParams.get("url"), 
         context.env.EdgeSubDB, 
         URLObject.searchParams.get("show_host") === "true",
         JSON.parse(URLObject.searchParams.get("http_headers")),
     );
-    const ResponseBody = JSON.stringify(ParsedSubData)
-    
+
+    let ResponseBody = JSON.stringify(ParsedSubData, null, 4);
+
+    // 构建响应头
+    const responseHeaders = {
+        'Content-Type': 'application/json; charset=utf-8',
+        ...UpstreamHeaders
+    };
+
     return new Response(ResponseBody, {
-        status: 200,
-        headers: {
-            "Content-Type": "application/json, charset=utf-8",
-            "Content-Length": ResponseBody.length,
-        }
+        headers: responseHeaders
     })
 }

--- a/functions/sub/share-link.js
+++ b/functions/sub/share-link.js
@@ -5,7 +5,7 @@ export async function onRequest (context, isBase64 = false) {
     const { request } = context;
     const URLObject = new URL(request.url);
     // do convert
-    const Proxies = await getParsedSubData(
+    let { data: Proxies, headers: UpstreamHeaders } = await getParsedSubData(
         URLObject.searchParams.get("url"), 
         context.env.EdgeSubDB, 
         URLObject.searchParams.get("show_host") === "true",
@@ -25,11 +25,13 @@ export async function onRequest (context, isBase64 = false) {
         ShareLinkResponse = btoa(ShareLinkResponse);
     }
 
+    // 构建响应头
+    const responseHeaders = {
+        'Content-Type': 'text/plain; charset=utf-8',
+        ...UpstreamHeaders
+    };
+
     return new Response(ShareLinkResponse, {
-        status: 200,
-        headers: {
-            "Content-Type": "text/plain, charset=utf-8",
-            "Content-Length": ShareLinkResponse.length
-        }
+        headers: responseHeaders
     })
 }

--- a/functions/sub/sing-box.js
+++ b/functions/sub/sing-box.js
@@ -4,7 +4,7 @@ import getParsedSubData from "../internal/getParsedSubData.ts";
 export async function onRequest (context) {
     const { request } = context;
     const URLObject = new URL(request.url);
-    let Proxies = await getParsedSubData(
+    let { data: Proxies, headers: UpstreamHeaders } = await getParsedSubData(
         URLObject.searchParams.get("url"), 
         context.env.EdgeSubDB, 
         URLObject.searchParams.get("show_host") === "true",
@@ -39,13 +39,15 @@ export async function onRequest (context) {
         }
     }
 
-    const ResponseBody = JSON.stringify(SingBoxConfigObject)
+    let JSONString = JSON.stringify(SingBoxConfigObject, null, 4);
 
-    return new Response(ResponseBody, {
-        status: 200,
-        headers: {
-            "Content-Type": "application/json; charset=utf-8",
-            "Content-Length": ResponseBody.length,
-        }
+    // 构建响应头
+    const responseHeaders = {
+        'Content-Type': 'application/json; charset=utf-8',
+        ...UpstreamHeaders
+    };
+
+    return new Response(JSONString, {
+        headers: responseHeaders
     })
 }


### PR DESCRIPTION
- Pass the upstream server's `subscription-userinfo`, `profile-update-interval`, and `profile-web-page-url` response headers to the client.
- Modify `getParsedSubData.ts` to return the parsed data and upstream response headers.
- Modify `clash-meta.js`, `debug.js`, `share-link.js`, and `sing-box.js` to merge upstream response headers into the final response headers.

Fixed: #15 

![图片](https://github.com/user-attachments/assets/d6f7aef3-52af-44e6-b8f2-6864dedf52a9)
